### PR TITLE
Mimic like operator better

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -462,7 +462,7 @@ class Query
         }
 
         if ($operator == "like") {
-            $this->must[] = ["match" => [$name => $value]];
+            $this->must[] = ["wildcard" => [$name => $value]];
         }
 
         if ($operator == "exists") {


### PR DESCRIPTION
The 'like' sql operator would be better mimicked with a wildcard query filter, as it allows to replace the '%' sign by a '*', and otherwise works like the 'like' operator